### PR TITLE
Release 2.0.5

### DIFF
--- a/ImageLibrary.csproj
+++ b/ImageLibrary.csproj
@@ -40,6 +40,61 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <DocumentationFile>bin\Release\Kaliko.ImageLibrary.XML</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 2.0|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <DocumentationFile>..\.build\net20\Kaliko.ImageLibrary.XML</DocumentationFile>
+    <OutputPath>..\.build\net20\</OutputPath>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 3.0|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <DocumentationFile>..\.build\net30\Kaliko.ImageLibrary.XML</DocumentationFile>
+    <OutputPath>..\.build\net30\</OutputPath>
+    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 3.5|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <DocumentationFile>..\.build\net35\Kaliko.ImageLibrary.XML</DocumentationFile>
+    <OutputPath>..\.build\net35\</OutputPath>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 4.0|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <DocumentationFile>..\.build\net40\Kaliko.ImageLibrary.XML</DocumentationFile>
+    <OutputPath>..\.build\net40\</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 4.5|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <DocumentationFile>..\.build\net45\Kaliko.ImageLibrary.XML</DocumentationFile>
+    <OutputPath>..\.build\net45\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/ImageLibrary.sln
+++ b/ImageLibrary.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageLibrary", "ImageLibrary.csproj", "{073C7180-35E8-442A-9334-AA3F529C0985}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp", "TestApp\TestApp.csproj", "{4381B75F-8E8B-4F82-AABC-A16AD72D201A}"

--- a/KalikoImage.cs
+++ b/KalikoImage.cs
@@ -55,6 +55,9 @@ namespace Kaliko.ImageLibrary {
         public KalikoImage(Image image) {
             TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
             Image = image;
+
+            MakeImageNonIndexed();
+
             _g = Graphics.FromImage(Image);
         }
 
@@ -334,7 +337,9 @@ namespace Kaliko.ImageLibrary {
         /// </summary>
         /// <param name="fileName">File path</param>
         public void LoadImage(string fileName) {
-            Image = Image.FromFile(fileName);
+            using (var bitmap = new Bitmap(fileName)) {
+                Image = new Bitmap(bitmap);
+            }
 
             MakeImageNonIndexed();
 
@@ -346,7 +351,9 @@ namespace Kaliko.ImageLibrary {
         /// </summary>
         /// <param name="stream">Pointer to stream</param>
         public void LoadImage(Stream stream) {
-            Image = Image.FromStream(stream);
+            using (var bitmap = new Bitmap(stream)) {
+                Image = new Bitmap(bitmap);
+            }
 
             MakeImageNonIndexed();
 
@@ -439,8 +446,7 @@ namespace Kaliko.ImageLibrary {
 
 
 
-        internal static void DrawScaledImage(
-            KalikoImage destinationImage, KalikoImage sourceImage, int x, int y, int width, int height) {
+        internal static void DrawScaledImage(KalikoImage destinationImage, KalikoImage sourceImage, int x, int y, int width, int height) {
             DrawScaledImage(destinationImage.Image, sourceImage.Image, x, y, width, height);
         }
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,31 @@
+### New in 2.0.5
+* Rewritten file loader to prevent file locks
+* Fixed image loading to ignore pixel-per-inch resolutions of original images
+* Fixed constructor using System.Drawing.Image to support indexed palettes
+
+### New in 2.0.4
+* Added new TextField class for better text support
+* Fixed scaling bug and updated test program 
+
+### New in 2.0.0
+* Replaced Gaussian blur filter with better implementation (affects unsharpen masks)
+* Added chroma key filter
+* Rewritten API for Scaling
+* Added color space handling
+
+### New in 1.2.4
+* Updated to Visual Studio 2010.
+* Code clean-up.
+* Unwanted-border-artifact-problem fixed (thanks Richard!)
+* IDisponable has been implemented.
+
+### New in 1.2.3
+* Minor changes.
+* First API documentation uploaded. Still missing a whole lot, but it's a start :)
+
+### New in 1.2.2
+* Minor changes
+
+### New in 1.2.1
+* Bug in thumbnail function fixed.
+* Code cleaned up.


### PR DESCRIPTION
* Rewritten file loader to prevent file locks
* Fixed image loading to ignore pixel-per-inch resolutions of original images
* Fixed constructor using System.Drawing.Image to support indexed palettes