### PR TITLE
Add support for .netStandard 2.0

### DIFF
--- a/FastFilters/ImageLibrary.FastFilters.NetStd.csproj
+++ b/FastFilters/ImageLibrary.FastFilters.NetStd.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="FastContrastFilter.cs" />
+    <Compile Include="FastBrightnessFilter.cs" />
+    <Compile Include="FastChromaKeyFilter.cs" />
+    <Compile Include="FastUnsharpMaskFilter.cs" />
+    <Compile Include="FastDesaturationFilter.cs" />
+    <Compile Include="FastInvertFilter.cs" />
+    <Compile Include="FastGaussianBlur.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ImageLibrary.NetStd.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+</Project>

--- a/ImageLibrary.NetCore.csproj
+++ b/ImageLibrary.NetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />
@@ -14,7 +14,7 @@
     <Copyright>Copyright © Fredrik Schultz and Contributors</Copyright>
     <Authors>ImageLibrary.NetStdss</Authors>
     <Version>3.0.2</Version>
-    <AssemblyName>Kaliko Image Library - NetStandard 2.0</AssemblyName>
+    <AssemblyName>Kaliko Image Library - NetCore</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -56,6 +56,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="System.IO" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ImageLibrary.NetStd.csproj
+++ b/ImageLibrary.NetStd.csproj
@@ -1,0 +1,64 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ApplicationIcon />
+    <OutputType>Library</OutputType>
+    <StartupObject />
+    <RootNamespace>ImageLibrary</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <Product>ImageLibrary</Product>
+    <Description>.NET library for easy image handling like cropping, thumbnails, streaming and more</Description>
+    <Company>Kaliko</Company>
+    <PackageId>Kaliko Image Library</PackageId>
+    <Copyright>Copyright © Fredrik Schultz and Contributors</Copyright>
+    <Authors>ImageLibrary.NetStdss</Authors>
+    <Version>3.0.2</Version>
+    <AssemblyName>Kaliko Image Library - NetStandard 2.0</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="ImageOutput.cs" />
+    <None Remove="Properties\AssemblyInfo.cs" />
+    <None Remove="Properties\SolutionInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="ColorHandler.cs" />
+    <Compile Include="ColorSpace\CIELab.cs" />
+    <Compile Include="ColorSpace\CIEXYZ.cs" />
+    <Compile Include="ColorSpace\CMYK.cs" />
+    <Compile Include="ColorSpace\ColorSpaceHelper.cs" />
+    <Compile Include="ColorSpace\HSB.cs" />
+    <Compile Include="ColorSpace\HSL.cs" />
+    <Compile Include="ColorSpace\RGB.cs" />
+    <Compile Include="ColorSpace\YUV.cs" />
+    <Compile Include="Filters\BrightnessFilter.cs" />
+    <Compile Include="Filters\ChromaKeyFilter.cs" />
+    <Compile Include="Filters\ContrastFilter.cs" />
+    <Compile Include="Filters\ConvolveFilter.cs" />
+    <Compile Include="Filters\DesaturationFilter.cs" />
+    <Compile Include="Filters\IFilter.cs" />
+    <Compile Include="Filters\InvertFilter.cs" />
+    <Compile Include="Filters\Kernel.cs" />
+    <Compile Include="Filters\GaussianBlurFilter.cs" />
+    <Compile Include="Filters\UnsharpMaskFilter.cs" />
+    <Compile Include="ImageOutput.cs" />
+    <Compile Include="KalikoImage.cs" />
+    <Compile Include="Scaling\CropScaling.cs" />
+    <Compile Include="Scaling\FitScaling.cs" />
+    <Compile Include="Scaling\PadScaling.cs" />
+    <Compile Include="Scaling\ScalingBase.cs" />
+    <Compile Include="TextField.cs" />
+    <Compile Include="TextShadow.cs" />
+    <Compile Include="ThumbnailMethod.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+</Project>

--- a/ImageLibrary.sln
+++ b/ImageLibrary.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2047
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageLibrary", "ImageLibrary.csproj", "{073C7180-35E8-442A-9334-AA3F529C0985}"
 EndProject
@@ -15,6 +15,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageLibrary.FastFilters", "FastFilters\ImageLibrary.FastFilters.csproj", "{8F14659B-DF8B-45ED-A5CB-72F09DC44DF1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageLibrary.NetStd", "ImageLibrary.NetStd.csproj", "{AEE90BCC-AC18-4D0D-B9EB-10A770BD96B6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageLibrary.FastFilters.NetStd", "FastFilters\ImageLibrary.FastFilters.NetStd.csproj", "{B9DCC05A-91DA-4E5F-A165-C35EEB774078}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp - NetStandard", "TestApp\TestApp - NetStandard.csproj", "{4D8979A1-9E38-4B7E-A21B-380F87B0D837}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,8 +40,23 @@ Global
 		{8F14659B-DF8B-45ED-A5CB-72F09DC44DF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F14659B-DF8B-45ED-A5CB-72F09DC44DF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F14659B-DF8B-45ED-A5CB-72F09DC44DF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEE90BCC-AC18-4D0D-B9EB-10A770BD96B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEE90BCC-AC18-4D0D-B9EB-10A770BD96B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEE90BCC-AC18-4D0D-B9EB-10A770BD96B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEE90BCC-AC18-4D0D-B9EB-10A770BD96B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9DCC05A-91DA-4E5F-A165-C35EEB774078}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9DCC05A-91DA-4E5F-A165-C35EEB774078}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9DCC05A-91DA-4E5F-A165-C35EEB774078}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9DCC05A-91DA-4E5F-A165-C35EEB774078}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D8979A1-9E38-4B7E-A21B-380F87B0D837}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D8979A1-9E38-4B7E-A21B-380F87B0D837}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D8979A1-9E38-4B7E-A21B-380F87B0D837}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D8979A1-9E38-4B7E-A21B-380F87B0D837}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DDCED142-1386-44DB-870B-14AC27ADB649}
 	EndGlobalSection
 EndGlobal

--- a/ImageOutput.cs
+++ b/ImageOutput.cs
@@ -45,6 +45,10 @@ namespace Kaliko.ImageLibrary {
             return null;
         }
 
+#if !NETSTANDARD2_0
+    // httpresponse doesn't exist in netStandard, at least not in the same way. Can't
+    // get the outputstream, even if you use the extensions & abstractons packages. 
+
         internal static Stream PrepareImageStream(string fileName, string mime) {
             HttpResponse stream = HttpContext.Current.Response;
             stream.Clear();
@@ -54,8 +58,9 @@ namespace Kaliko.ImageLibrary {
             stream.AddHeader("Content-Disposition", "inline;filename=" + fileName);
             return stream.OutputStream;
         }
+#endif
 
-        internal static void SaveStream(KalikoImage image, Stream stream, long quality, string imageFormat, bool saveResolution) {
+    internal static void SaveStream(KalikoImage image, Stream stream, long quality, string imageFormat, bool saveResolution) {
             var encoderParameters = GetEncoderParameters(quality);
             var encoderInfo = GetEncoderInfo(imageFormat);
 

--- a/ImageOutput.cs
+++ b/ImageOutput.cs
@@ -45,7 +45,7 @@ namespace Kaliko.ImageLibrary {
             return null;
         }
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NETCOREAPP2_1 && !NETCOREAPP2_2
     // httpresponse doesn't exist in netStandard, at least not in the same way. Can't
     // get the outputstream, even if you use the extensions & abstractons packages. 
 

--- a/KalikoImage.cs
+++ b/KalikoImage.cs
@@ -678,22 +678,19 @@ namespace Kaliko.ImageLibrary {
 
             Image = image.Image;
         }
-
-
         #endregion
-
 
         #region Functions for image saving and streaming
 
+#if !NETSTANDARD2_0
         /// <summary>Save image to the response stream in JPG-format. Ideal for sending realtime generated images to the web client requesting it.</summary>
         /// <param name="quality"></param>
         /// <param name="fileName"></param>
         /// <remarks>This method will set the proper HTTP-headers such as filename and mime-type.</remarks>
-        public void StreamJpg(long quality, string fileName) {
-            var imageStream = ImageOutput.PrepareImageStream(fileName, "image/jpeg");
-            SaveJpg(imageStream, quality);
+         public void StreamJpg(long quality, string fileName) {
+          var imageStream = ImageOutput.PrepareImageStream(fileName, "image/jpeg");
+          SaveJpg(imageStream, quality);
         }
-
 
         /// <summary>
         /// Save image to the response stream in PNG-format. Ideal for sending realtime generated images to the web client requesting it.
@@ -712,19 +709,19 @@ namespace Kaliko.ImageLibrary {
             var imageStream = ImageOutput.PrepareImageStream(fileName, "image/gif");
             SaveGif(imageStream);
         }
+#endif
 
-
-        /// <summary>Save image to stream in JPG-format</summary>
-        /// <param name="stream">Stream to save the image to</param>
-        /// <param name="quality">Compression quality setting (0-100)</param>
-        /// <param name="saveResolution">Save original/user-defined resolution</param>
-        /// <example>
-        /// 	<code title="Example" description="" lang="CS">
-        /// // Save image to stream in jpg format with quality setting 90
-        /// MemoryStream memoryStream = new MemoryStream();
-        /// image.SaveJpg(memoryStream, 90, true);</code>
-        /// </example>
-        public void SaveJpg(Stream stream, long quality, bool saveResolution) {
+    /// <summary>Save image to stream in JPG-format</summary>
+    /// <param name="stream">Stream to save the image to</param>
+    /// <param name="quality">Compression quality setting (0-100)</param>
+    /// <param name="saveResolution">Save original/user-defined resolution</param>
+    /// <example>
+    /// 	<code title="Example" description="" lang="CS">
+    /// // Save image to stream in jpg format with quality setting 90
+    /// MemoryStream memoryStream = new MemoryStream();
+    /// image.SaveJpg(memoryStream, 90, true);</code>
+    /// </example>
+    public void SaveJpg(Stream stream, long quality, bool saveResolution) {
             ImageOutput.SaveStream(this, stream, quality, "image/jpeg", saveResolution);
         }
 
@@ -919,10 +916,10 @@ namespace Kaliko.ImageLibrary {
         }
 
 
-        #endregion
+#endregion
 
 
-        #region Functions for filters and bitmap manipulation
+#region Functions for filters and bitmap manipulation
 
         private byte[] _byteArray;
         private bool _disposed;
@@ -994,10 +991,10 @@ namespace Kaliko.ImageLibrary {
             filter.Run(this);
         }
 
-        #endregion
+#endregion
 
 
-        #region Functions for rotation
+#region Functions for rotation
 
         /// <summary>
         /// Rotates, flips, or rotates and flips the image
@@ -1008,7 +1005,7 @@ namespace Kaliko.ImageLibrary {
             _g = Graphics.FromImage(Image);
         }
 
-        #endregion
+#endregion
 
         /// <summary>Int array matching PixelFormat.Format32bppArgb (bgrA in real life)</summary>
         public int[] IntArray {
@@ -1062,7 +1059,7 @@ namespace Kaliko.ImageLibrary {
         }
 
 
-        #region Deprecated methods only kept for legacy
+#region Deprecated methods only kept for legacy
 
         /// <exclude/>
         /// <excludetoc/>
@@ -1092,6 +1089,6 @@ namespace Kaliko.ImageLibrary {
             return Scale(scaleEngine);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/KalikoImage.cs
+++ b/KalikoImage.cs
@@ -678,11 +678,11 @@ namespace Kaliko.ImageLibrary {
 
             Image = image.Image;
         }
-        #endregion
+    #endregion
 
-        #region Functions for image saving and streaming
+    #region Functions for image saving and streaming
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NETCOREAPP2_1 && !NETCOREAPP2_2
         /// <summary>Save image to the response stream in JPG-format. Ideal for sending realtime generated images to the web client requesting it.</summary>
         /// <param name="quality"></param>
         /// <param name="fileName"></param>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Current build contains the following filters:
 If you plan using this library with WPF or simular, read this post on <a href="http://labs.kaliko.com/2011/03/convert-to-bitmapimage.html">how to convert an KalikoImage object to System.Windows.Media.Imaging.BitmapImage and System.Windows.Controls.Image</a>.
 
 ## History
+**3.0.2**
+* Fixed bug where BlitFill doesn't properly fill portrait sized images
+
+**3.0.1**
+* Added option to prevent upscaling when resizing images
+
 **3.0.0**
 * Added faster filter alternatives for full trust environmnets
 * Added SetResolution functions

--- a/TestApp/TestApp - NetStandard.csproj
+++ b/TestApp/TestApp - NetStandard.csproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{4D8979A1-9E38-4B7E-A21B-380F87B0D837}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TestApp</RootNamespace>
+    <AssemblyName>TestApp</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.4.5.0\lib\net461\System.Drawing.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="testimage.jpg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ImageLibrary.NetStd.csproj">
+      <Project>{aee90bcc-ac18-4d0d-b9eb-10a770bd96b6}</Project>
+      <Name>ImageLibrary.NetStd</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
i'm working on a Xamarin Forms project which requires the use of .netStandard 2.0 in one library. I made changes to support it, mainly removing the http streaming functions, as things like HttpContext and HttpResponse don't exist in .netStandard in the same way they do in .net 2.0. I tried to find workarounds, but wasn't successful so far. Would take major refactoring of the save* methods to accomplish it. 